### PR TITLE
recreate symbolic links on docker (windows compatibility)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,10 @@ COPY --chown=solr:solr ./var/solr/data/opensemanticsearch /var/solr/data/opensem
 
 COPY --chown=solr:solr ./src/open-semantic-entity-search-api/src/solr/opensemanticsearch-entities /var/solr/data/opensemanticsearch-entities
 
+# Recreate symbolic links for hunspell (required for windows compatibility)
+RUN rm /opt/solr/server/solr/opensemanticsearch/conf/lang/hunspell
+RUN rm /opt/solr/server/solr/opensemanticsearch-entities/conf/lang/hunspell
+RUN ln -s /usr/share/hunspell /opt/solr/server/solr/opensemanticsearch/conf/lang/hunspell
+RUN ln -s /usr/share/hunspell /opt/solr/server/solr/opensemanticsearch-entities/conf/lang/hunspell
+
 USER solr


### PR DESCRIPTION
Sym links are not treated well in windows. For being able to build the docker image properly on a windows system one has to recreate the sym links.