### PR TITLE
Make Solr listening address configurable

### DIFF
--- a/etc/default/solr.in.sh
+++ b/etc/default/solr.in.sh
@@ -169,7 +169,7 @@ SOLR_OPTS="$SOLR_OPTS -Dsolr.autoCommit.maxTime=60000"
 #SOLR_REQUESTLOG_ENABLED=false
 
 # Bind Solr to localhost, so not directly available outside this machine
-SOLR_OPTS="$SOLR_OPTS -Djetty.host=127.0.0.1"
+SOLR_OPTS="$SOLR_OPTS -Djetty.host=${SOLR_LOCAL_HOST:-localhost}"
 
 # Sets the port Solr binds to, default is 8983
 #SOLR_PORT=8983


### PR DESCRIPTION
Having Solr listen only on localhost breaks the docker-compose setup
as the Solr container needs to be reachable from the other containers.

The name SOLR_LOCAL_HOST was chosen to match upstream Solr naming.